### PR TITLE
docs: Add release planning to maintainer skill [v0.3]

### DIFF
--- a/.claude/skills/snowtower-maintainer/SKILL.md
+++ b/.claude/skills/snowtower-maintainer/SKILL.md
@@ -193,6 +193,60 @@ This skill works with:
 - **Documentation**: `docs/`
 - **Claude config**: `.claude/`
 
+## Release Planning
+
+### Identify What Goes in a Release
+
+1. **Check open issues:**
+   ```bash
+   gh issue list --state open --label P1
+   gh issue list --state open
+   ```
+
+2. **Review workspace roadmap:**
+   - Check `/Users/ssciortino/Projects/snowtower-workspace/CLAUDE.md` for:
+     - "Strategic Recommendations & Next Steps" section
+     - Priority 1/2/3 items
+     - Technical debt to address
+
+3. **Gather completed work since last release:**
+   ```bash
+   git log v0.X..main --oneline
+   ```
+
+### Create Version Branch
+
+```bash
+# Create and push version branch
+git checkout main
+git pull origin main
+git checkout -b v0.X
+git push -u origin v0.X
+```
+
+### Pre-Release Checklist
+
+1. **Run full test suite:** `uv run pytest`
+2. **Update CHANGELOG.md** with new features
+3. **Verify README is current** (badges, commands, stats)
+4. **Check documentation links** resolve correctly
+5. **Create PR to main** with release summary
+
+### Release Workflow
+
+```bash
+# After PR is merged
+git checkout main
+git pull
+gh release create vX.Y --title "vX.Y - Title" --notes "..."
+```
+
+### Version Naming
+
+- **v0.X**: Pre-1.0 development releases
+- **v1.0**: First stable release (target: installable CLI)
+- **vX.Y.Z**: Semantic versioning post-1.0
+
 ## When to Trigger
 
 Invoke this skill when:
@@ -203,3 +257,5 @@ Invoke this skill when:
 - After significant feature additions
 - Before releases to ensure docs are current
 - When onboarding new contributors
+- **User asks to plan a new release version**
+- **User wants to start work on vX.Y**


### PR DESCRIPTION
## Summary

Enhanced the snowtower-maintainer skill with release planning guidance.

### Changes
- Added release planning section:
  - How to identify what goes in a release (issues, roadmap review)
  - Version branch creation workflow
  - Pre-release checklist
  - Release workflow steps
  - Version naming conventions

## v0.3 Planning

Created milestone and issues for v0.3:
- #16: Decouple SnowDDL configs from CLI (P1)
- #19: Add configuration validation command
- #20: Enhanced integration testing
- #21: Complete documentation modernization
- #22: Add secrets scanning to CI

**Milestone:** https://github.com/Database-Tycoon/SnowTower/milestone/2

## Test plan
- [x] Skill file syntax valid
- [x] Instructions accurate and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)